### PR TITLE
Update Nuxt dependency version string

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -21,7 +21,7 @@
     "axios": "^0.15.3",
     "cross-env": "^3.1.4",
     "express": "^4.14.0",
-    "nuxt": "latest"
+    "nuxt": "~0.10.5"
   },
   "devDependencies": {
     "babel-cli": "^6.22.2",


### PR DESCRIPTION
I think locking down the Nuxt version some would prevent some bugs from creeping into nuxt/express when breaking changes appear in Nuxt.

I've used the `~` here to lock it to patch version updates only, because Nuxt is publishing breaking changes with minor version bumps. This way we will have to explicitly change the version anytime there is a breaking change, at which point we can make any needed changes in the template code.

It will mean more frequent updates to this repo will be necessary(mostly prior to nuxt@1.0.0) but it should also mean less confusion for users and less issues/PRs being opened.