### PR TITLE
Fixed import problem on windows

### DIFF
--- a/template/plugins/axios.js
+++ b/template/plugins/axios.js
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import * as axios from 'axios'
 
 let options = {}
 // The server-side needs a full url to works


### PR DESCRIPTION
Previous version works at os x, but doesn't fire at windows, it fails. Importing all module as axios fixes that issue.
fix for #38 